### PR TITLE
SAML/MAX Fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     "wpackagist-plugin/google-analyticator": "~6",
     "wpackagist-plugin/m-wp-popup": "~1",
     "wpackagist-plugin/no-category-base-wpml": "1.3",
-    "wpackagist-plugin/onelogin-saml-sso": "~2",
     "wpackagist-plugin/plugin-vulnerabilities": "~2",
     "wpackagist-plugin/posts-in-page": "~1",
     "wpackagist-plugin/redirection": "~3",

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "wpackagist-plugin/google-analyticator": "~6",
     "wpackagist-plugin/m-wp-popup": "~1",
     "wpackagist-plugin/no-category-base-wpml": "1.3",
+    "wpackagist-plugin/onelogin-saml-sso": "~2",
     "wpackagist-plugin/plugin-vulnerabilities": "~2",
     "wpackagist-plugin/posts-in-page": "~1",
     "wpackagist-plugin/redirection": "~3",

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "gsa/arcgis-map": "dev-master",
     "gsa/bwp-external-links": "dev-master",
     "gsa/custom-permalinks": "dev-master",
-    "gsa/custom-post-view-generator": "dev-master",
+    "gsa/custom-post-view-generator": "dev-fix-link-template-error",
     "gsa/data.gov": "dev-master",
     "gsa/datagov-custom": "dev-master",
     "gsa/inactive-logout": "dev-master",
@@ -109,7 +109,7 @@
     },
     {
       "type": "git",
-      "url": "https://github.com/GSA/custom-post-view-generator",
+      "url": "https://github.com/SkipKeats/custom-post-view-generator.git",
       "no-api": true
     },
     {

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "gsa/arcgis-map": "dev-master",
     "gsa/bwp-external-links": "dev-master",
     "gsa/custom-permalinks": "dev-master",
-    "gsa/custom-post-view-generator": "dev-fix-link-template-error",
+    "gsa/custom-post-view-generator": "dev-master",
     "gsa/data.gov": "dev-master",
     "gsa/datagov-custom": "dev-master",
     "gsa/inactive-logout": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -109,7 +109,7 @@
     },
     {
       "type": "git",
-      "url": "https://github.com/SkipKeats/custom-post-view-generator.git",
+      "url": "https://github.com/GSA/custom-post-view-generator.git",
       "no-api": true
     },
     {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7252ecaa8ceea7aed0f81212a5a081b0",
+    "content-hash": "94d37b4d3b2003bf7a4c218fc3c5e4ed",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.64.13",
+            "version": "3.64.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "daff999e06bc5334e9bb90286514f1c2db0c4cbb"
+                "reference": "22ad993c1ed7a85d660768d30d773babbc7d38bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/daff999e06bc5334e9bb90286514f1c2db0c4cbb",
-                "reference": "daff999e06bc5334e9bb90286514f1c2db0c4cbb",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/22ad993c1ed7a85d660768d30d773babbc7d38bd",
+                "reference": "22ad993c1ed7a85d660768d30d773babbc7d38bd",
                 "shasum": ""
             },
             "require": {
@@ -84,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2018-08-15T23:03:41+00:00"
+            "time": "2018-08-17T20:48:05+00:00"
         },
         {
             "name": "composer/installers",
@@ -328,13 +328,13 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/GSA/saml-20-single-sign-on",
-                "reference": "4455ea0e6ad8178dacd3e6b196bfc16edf00af63"
+                "reference": "4e08bd927d3108fd8444d174f1bd2669afa2ca26"
             },
             "require": {
                 "composer/installers": "~1.0"
             },
             "type": "wordpress-plugin",
-            "time": "2018-04-05T16:09:30+00:00"
+            "time": "2018-08-20T16:16:39+00:00"
         },
         {
             "name": "gsa/sticky-posts-in-category",
@@ -1532,26 +1532,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/no-category-base-wpml/"
-        },
-        {
-            "name": "wpackagist-plugin/onelogin-saml-sso",
-            "version": "2.8.0",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/onelogin-saml-sso/",
-                "reference": "trunk"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/onelogin-saml-sso.zip?timestamp=1530572800",
-                "reference": null,
-                "shasum": null
-            },
-            "require": {
-                "composer/installers": "~1.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/onelogin-saml-sso/"
         },
         {
             "name": "wpackagist-plugin/plugin-vulnerabilities",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b9442e5f9c3faf75b221d8595cff47a",
+    "content-hash": "94d37b4d3b2003bf7a4c218fc3c5e4ed",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.64.1",
+            "version": "3.64.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "675481fc1bfdab312c0236f36ea93818a7c098eb"
+                "reference": "1fa00e20adc697ae996b778528254d3acff39eaa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/675481fc1bfdab312c0236f36ea93818a7c098eb",
-                "reference": "675481fc1bfdab312c0236f36ea93818a7c098eb",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/1fa00e20adc697ae996b778528254d3acff39eaa",
+                "reference": "1fa00e20adc697ae996b778528254d3acff39eaa",
                 "shasum": ""
             },
             "require": {
@@ -84,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2018-07-30T20:41:52+00:00"
+            "time": "2018-08-07T20:30:32+00:00"
         },
         {
             "name": "composer/installers",
@@ -252,10 +252,10 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/SkipKeats/custom-post-view-generator.git",
-                "reference": "450e4fe4b2baf3e0a57bbf1e452d221bc6e00a77"
+                "reference": "ab8cb20aa16a077fbfadc50e71c530bcc7f23e98"
             },
             "type": "wordpress-plugin",
-            "time": "2018-07-30T19:14:35+00:00"
+            "time": "2018-08-08T14:49:41+00:00"
         },
         {
             "name": "gsa/data.gov",
@@ -603,20 +603,20 @@
         },
         {
             "name": "johnpbloch/wordpress",
-            "version": "4.9.7",
+            "version": "4.9.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress.git",
-                "reference": "6697a15cdfd60cfdf9f4bf04a4e7637a8d2a5afa"
+                "reference": "de02cd79a41e06f36558040724414197cb7f6246"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/6697a15cdfd60cfdf9f4bf04a4e7637a8d2a5afa",
-                "reference": "6697a15cdfd60cfdf9f4bf04a4e7637a8d2a5afa",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/de02cd79a41e06f36558040724414197cb7f6246",
+                "reference": "de02cd79a41e06f36558040724414197cb7f6246",
                 "shasum": ""
             },
             "require": {
-                "johnpbloch/wordpress-core": "4.9.7",
+                "johnpbloch/wordpress-core": "4.9.8",
                 "johnpbloch/wordpress-core-installer": "^1.0",
                 "php": ">=5.3.2"
             },
@@ -638,27 +638,27 @@
                 "cms",
                 "wordpress"
             ],
-            "time": "2018-07-05T18:12:19+00:00"
+            "time": "2018-08-02T21:48:39+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core",
-            "version": "4.9.7",
+            "version": "4.9.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress-core.git",
-                "reference": "1116e10f71f8fb811856df212af652c427bc6bd1"
+                "reference": "50323f9b91d7689d615b4af02caf9d80584b1cfc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/1116e10f71f8fb811856df212af652c427bc6bd1",
-                "reference": "1116e10f71f8fb811856df212af652c427bc6bd1",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/50323f9b91d7689d615b4af02caf9d80584b1cfc",
+                "reference": "50323f9b91d7689d615b4af02caf9d80584b1cfc",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
             },
             "provide": {
-                "wordpress/core-implementation": "4.9.7"
+                "wordpress/core-implementation": "4.9.8"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -678,7 +678,7 @@
                 "cms",
                 "wordpress"
             ],
-            "time": "2018-07-05T18:12:13+00:00"
+            "time": "2018-08-02T21:48:32+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",
@@ -1048,25 +1048,28 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -1099,7 +1102,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-04-30T19:57:29+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1252,15 +1255,15 @@
         },
         {
             "name": "wpackagist-plugin/amazon-s3-and-cloudfront",
-            "version": "1.4.2",
+            "version": "1.4.3",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/amazon-s3-and-cloudfront/",
-                "reference": "tags/1.4.2"
+                "reference": "tags/1.4.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/amazon-s3-and-cloudfront.1.4.2.zip",
+                "url": "https://downloads.wordpress.org/plugin/amazon-s3-and-cloudfront.1.4.3.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -1452,15 +1455,15 @@
         },
         {
             "name": "wpackagist-plugin/flamingo",
-            "version": "1.8",
+            "version": "1.9",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/flamingo/",
-                "reference": "tags/1.8"
+                "reference": "tags/1.9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/flamingo.1.8.zip",
+                "url": "https://downloads.wordpress.org/plugin/flamingo.1.9.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -1632,15 +1635,15 @@
         },
         {
             "name": "wpackagist-plugin/the-events-calendar",
-            "version": "4.6.20.1",
+            "version": "4.6.21",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/the-events-calendar/",
-                "reference": "tags/4.6.20.1"
+                "reference": "tags/4.6.21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/the-events-calendar.4.6.20.1.zip",
+                "url": "https://downloads.wordpress.org/plugin/the-events-calendar.4.6.21.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -1692,15 +1695,15 @@
         },
         {
             "name": "wpackagist-plugin/wordpress-seo",
-            "version": "7.9",
+            "version": "7.9.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wordpress-seo/",
-                "reference": "tags/7.9"
+                "reference": "tags/7.9.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.7.9.zip",
+                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.7.9.1.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -2036,16 +2039,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.6",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
@@ -2057,12 +2060,12 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -2095,7 +2098,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-04-18T13:57:24+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94d37b4d3b2003bf7a4c218fc3c5e4ed",
+    "content-hash": "8c414545cfc6487817af37d17a6e9246",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.64.15",
+            "version": "3.66.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "22ad993c1ed7a85d660768d30d773babbc7d38bd"
+                "reference": "eefa7317be6a8aceacf10364ea964e70fc7647f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/22ad993c1ed7a85d660768d30d773babbc7d38bd",
-                "reference": "22ad993c1ed7a85d660768d30d773babbc7d38bd",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/eefa7317be6a8aceacf10364ea964e70fc7647f8",
+                "reference": "eefa7317be6a8aceacf10364ea964e70fc7647f8",
                 "shasum": ""
             },
             "require": {
@@ -84,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2018-08-17T20:48:05+00:00"
+            "time": "2018-08-25T00:49:07+00:00"
         },
         {
             "name": "composer/installers",
@@ -252,10 +252,10 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/SkipKeats/custom-post-view-generator.git",
-                "reference": "ab8cb20aa16a077fbfadc50e71c530bcc7f23e98"
+                "reference": "d3252712b28b23b40e59b4480b778585ffe3a292"
             },
             "type": "wordpress-plugin",
-            "time": "2018-08-08T14:49:41+00:00"
+            "time": "2018-08-24T19:47:18+00:00"
         },
         {
             "name": "gsa/data.gov",
@@ -328,13 +328,13 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/GSA/saml-20-single-sign-on",
-                "reference": "4e08bd927d3108fd8444d174f1bd2669afa2ca26"
+                "reference": "024505182385207ce20904f8768d483a81dfb01d"
             },
             "require": {
                 "composer/installers": "~1.0"
             },
             "type": "wordpress-plugin",
-            "time": "2018-08-20T16:16:39+00:00"
+            "time": "2018-08-27T16:43:15+00:00"
         },
         {
             "name": "gsa/sticky-posts-in-category",
@@ -1635,15 +1635,15 @@
         },
         {
             "name": "wpackagist-plugin/the-events-calendar",
-            "version": "4.6.21",
+            "version": "4.6.22",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/the-events-calendar/",
-                "reference": "tags/4.6.21"
+                "reference": "tags/4.6.22"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/the-events-calendar.4.6.21.zip",
+                "url": "https://downloads.wordpress.org/plugin/the-events-calendar.4.6.22.zip",
                 "reference": null,
                 "shasum": null
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c414545cfc6487817af37d17a6e9246",
+    "content-hash": "3f04dcb169b243615d59f75fdf90f4f4",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -248,14 +248,14 @@
         },
         {
             "name": "gsa/custom-post-view-generator",
-            "version": "dev-fix-link-template-error",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/SkipKeats/custom-post-view-generator.git",
-                "reference": "d3252712b28b23b40e59b4480b778585ffe3a292"
+                "url": "https://github.com/GSA/custom-post-view-generator.git",
+                "reference": "eba8af9517c658cf9484b961fb221b2a977d52ef"
             },
             "type": "wordpress-plugin",
-            "time": "2018-08-24T19:47:18+00:00"
+            "time": "2017-10-27T20:36:03+00:00"
         },
         {
             "name": "gsa/data.gov",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94d37b4d3b2003bf7a4c218fc3c5e4ed",
+    "content-hash": "7252ecaa8ceea7aed0f81212a5a081b0",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.64.7",
+            "version": "3.64.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "1fa00e20adc697ae996b778528254d3acff39eaa"
+                "reference": "daff999e06bc5334e9bb90286514f1c2db0c4cbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/1fa00e20adc697ae996b778528254d3acff39eaa",
-                "reference": "1fa00e20adc697ae996b778528254d3acff39eaa",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/daff999e06bc5334e9bb90286514f1c2db0c4cbb",
+                "reference": "daff999e06bc5334e9bb90286514f1c2db0c4cbb",
                 "shasum": ""
             },
             "require": {
@@ -84,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2018-08-07T20:30:32+00:00"
+            "time": "2018-08-15T23:03:41+00:00"
         },
         {
             "name": "composer/installers",
@@ -1534,16 +1534,36 @@
             "homepage": "https://wordpress.org/plugins/no-category-base-wpml/"
         },
         {
-            "name": "wpackagist-plugin/plugin-vulnerabilities",
-            "version": "2.0.67",
+            "name": "wpackagist-plugin/onelogin-saml-sso",
+            "version": "2.8.0",
             "source": {
                 "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/plugin-vulnerabilities/",
-                "reference": "tags/2.0.67"
+                "url": "https://plugins.svn.wordpress.org/onelogin-saml-sso/",
+                "reference": "trunk"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/plugin-vulnerabilities.2.0.67.zip",
+                "url": "https://downloads.wordpress.org/plugin/onelogin-saml-sso.zip?timestamp=1530572800",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/onelogin-saml-sso/"
+        },
+        {
+            "name": "wpackagist-plugin/plugin-vulnerabilities",
+            "version": "2.0.68",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/plugin-vulnerabilities/",
+                "reference": "tags/2.0.68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/plugin-vulnerabilities.2.0.68.zip",
                 "reference": null,
                 "shasum": null
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f27353cc45bb02463cd5f0dc85745abf",
+    "content-hash": "7aa79ee089fa48056a6833014b4cf91b",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -248,14 +248,14 @@
         },
         {
             "name": "gsa/custom-post-view-generator",
-            "version": "dev-master",
+            "version": "dev-fix-link-template-error",
             "source": {
                 "type": "git",
-                "url": "https://github.com/GSA/custom-post-view-generator",
-                "reference": "eba8af9517c658cf9484b961fb221b2a977d52ef"
+                "url": "https://github.com/SkipKeats/custom-post-view-generator.git",
+                "reference": "450e4fe4b2baf3e0a57bbf1e452d221bc6e00a77"
             },
             "type": "wordpress-plugin",
-            "time": "2017-10-27T20:36:03+00:00"
+            "time": "2018-07-30T19:14:35+00:00"
         },
         {
             "name": "gsa/data.gov",
@@ -1162,16 +1162,16 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v2.5.0",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "6ae3e2e6494bb5e58c2decadafc3de7f1453f70a"
+                "reference": "8abb4f9aa89ddea9d52112c65bbe8d0125e2fa8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/6ae3e2e6494bb5e58c2decadafc3de7f1453f70a",
-                "reference": "6ae3e2e6494bb5e58c2decadafc3de7f1453f70a",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/8abb4f9aa89ddea9d52112c65bbe8d0125e2fa8e",
+                "reference": "8abb4f9aa89ddea9d52112c65bbe8d0125e2fa8e",
                 "shasum": ""
             },
             "require": {
@@ -1208,7 +1208,7 @@
                 "env",
                 "environment"
             ],
-            "time": "2018-07-01T10:25:50+00:00"
+            "time": "2018-07-29T20:33:41+00:00"
         },
         {
             "name": "wpackagist-plugin/advanced-custom-fields",


### PR DESCRIPTION
Fixes the SAML plugin by commenting out code that manipulates several URLs. Also will update WordPress to 4.9.8 and update several other plugins including AWS to most current versions.