### PR TITLE
Restore DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,15 @@ Activate all the installed plugins and theme.
 Open your browser to [localhost:8000](http://localhost:8000/).
 
 _TODO: initialize the database with seed data so the theme loads properly._
+
+### Restoring database dumps
+
+You don't need a database dump for most development tasks. If you need
+a database dump, you can create one following instructions from the
+[Runbook](https://github.com/GSA/datagov-deploy/wiki/Runbook#database-dump).
+
+Once you have the database dump, you can restore it for your local development
+environment.
+
+    $ docker-compose exec -T db mysql -u root -pmysql-dev-password datagov \
+      < <(gzip --to-stdout --decompress databasedump.sql.gz)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Run the docker containers.
 
     $ docker-compose up
 
+Install composer dependencies.
+
+    $ docker-compose exec app composer install
+
 Activate all the installed plugins and theme.
 
     $ docker-compose exec app wp core install --url=http://localhost:8000 \


### PR DESCRIPTION
Adds instructions on how to restore a database dump.

Also includes a note about the missing composer install step that everyone seems to be running into. I think there is actually a bug here in the docker-compose setup.