### PR TITLE
Integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,37 +2,16 @@
 version: 2
 jobs:
   build:
-    docker:
-      - image: circleci/php:7.1-jessie-node
+    machine: true
     steps:
       - checkout
-      - run: sudo apt install -y subversion
-      - restore_cache:
-          keys:
-            - v1-composer-{{ checksum "composer.lock" }}
-            - v1-composer-
-      - run: composer --no-interaction install
-      - save_cache:
-          key: v1-composer-{{ checksum "composer.lock" }}
-          paths:
-            - vendor
-      - run: sudo npm install -g snyk
-      - run: snyk test
+      - run: make build
+      - run: make configure
+      - run: make test
 
 
 workflows:
   version: 2
   commit:
-    jobs:
-      - build
-
-  weekly:
-    triggers:
-      - schedule:
-          cron: "0 4 * * 1"
-          filters:
-            branches:
-              only:
-                - master
     jobs:
       - build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: build configure test up
+
+build:
+	docker-compose build
+
+configure:
+	docker-compose up --detach
+	docker-compose exec app composer install
+	docker-compose exec app wp core install --url=http://localhost:8000 --title=Data.gov --admin_user=admin --admin_email=admin@example.com --allow-root
+	docker-compose exec app wp plugin activate --all --allow-root
+	docker-compose exec app wp theme activate roots-nextdatagov --allow-root
+
+test:
+	docker-compose -f docker-compose.yml -f docker-compose.test.yml build test
+	docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit test
+
+up:
+	docker-compose up

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ clean:
 	docker-compose down -v
 
 configure:
-	docker-compose up --detach
+	#docker-compose up --detach # Docker Compose on CI does not support --detach
+	docker-compose up &
 	docker-compose exec app composer install
 	docker-compose exec app wp core install --url=http://localhost:8000 --title=Data.gov --admin_user=admin --admin_email=admin@example.com --allow-root
 	docker-compose exec app wp plugin activate --all --allow-root

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: build configure test up
+.PHONY: build clean configure test up
 
 build:
 	docker-compose build
+
+clean:
+	docker-compose down -v
 
 configure:
 	docker-compose up --detach

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,10 @@ clean:
 	docker-compose down -v
 
 configure:
-	#docker-compose up --detach # Docker Compose on CI does not support --detach
-	docker-compose up &
-	docker-compose exec app composer install
-	docker-compose exec app wp core install --url=http://localhost:8000 --title=Data.gov --admin_user=admin --admin_email=admin@example.com --allow-root
-	docker-compose exec app wp plugin activate --all --allow-root
-	docker-compose exec app wp theme activate roots-nextdatagov --allow-root
+	docker-compose run --rm app composer install
+	docker-compose run --rm app wp core install --url=http://localhost:8000 --title=Data.gov --admin_user=admin --admin_email=admin@example.com --allow-root
+	docker-compose run --rm app wp plugin activate --all --allow-root
+	docker-compose run --rm app wp theme activate roots-nextdatagov --allow-root
 
 test:
 	docker-compose -f docker-compose.yml -f docker-compose.test.yml build test

--- a/README.md
+++ b/README.md
@@ -46,3 +46,15 @@ Activate all the installed plugins and theme.
 Open your browser to [localhost:8000](http://localhost:8000/).
 
 _TODO: initialize the database with seed data so the theme loads properly._
+
+### Restoring database dumps
+
+You don't need a database dump for most development tasks. If you need
+a database dump, you can create one following instructions from the
+[Runbook](https://github.com/GSA/datagov-deploy/wiki/Runbook#database-dump).
+
+Once you have the database dump, you can restore it for your local development
+environment.
+
+    $ docker-compose exec -T db mysql -u root -pmysql-dev-password datagov \
+      < <(gzip --to-stdout --decompress databasedump.sql.gz)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Run the docker containers.
 
     $ docker-compose up
 
+Install composer dependencies.
+
+    $ docker-compose exec app composer install
+
 Activate all the installed plugins and theme.
 
     $ docker-compose exec app wp core install --url=http://localhost:8000 \

--- a/README.md
+++ b/README.md
@@ -26,30 +26,27 @@ Most of Data.gov discussions happen at [Data.gov github](https://github.com/gsa/
 - [Docker](https://docs.docker.com/install/) v18+
 - [Docker Compose](https://docs.docker.com/compose/) v1.24+
 
+
 ### Setup
 
 Build the docker containers.
 
-    $ docker-compose build
+    $ make build
 
-Run the docker containers.
+Configure WordPress by installing the composer dependencies, installing
+WordPress, and configuring plugins and theme.
 
-    $ docker-compose up
-
-Install composer dependencies.
-
-    $ docker-compose exec app composer install
-
-Activate all the installed plugins and theme.
-
-    $ docker-compose exec app wp core install --url=http://localhost:8000 \
-      --title=Data.gov --admin_user=admin --admin_email=admin@example.com --allow-root
-    $ docker-compose exec app wp plugin activate --all --allow-root
-    $ docker-compose exec app wp theme activate roots-nextdatagov --allow-root
+    $ make configure
 
 Open your browser to [localhost:8000](http://localhost:8000/).
 
 _TODO: initialize the database with seed data so the theme loads properly._
+
+Once the containers are setup, you can just bring up the containers without
+running `make setup` each time.
+
+    $ make up
+
 
 ### Restoring database dumps
 
@@ -62,3 +59,14 @@ environment.
 
     $ docker-compose exec -T db mysql -u root -pmysql-dev-password datagov \
       < <(gzip --to-stdout --decompress databasedump.sql.gz)
+
+
+### Tests
+
+Make sure the app is setup and WordPress is installed.
+
+    $ make setup
+
+Then you can run the integration tests.
+
+    $ make test

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ running `make setup` each time.
 
     $ make up
 
+If you need to start from a clean state, remove any containers and volumes.
+
+    $ make clean
+
 
 ### Restoring database dumps
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,9 @@
+---
+version: "3"
+services:
+  test:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.test
+    depends_on:
+      - nginx

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,0 +1,8 @@
+FROM bats/bats
+
+RUN apk add curl
+
+COPY tests/ /tests/
+
+# bats/bats uses bats as the entrypoint
+CMD ["-r", "/tests"]

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+function wait_for () {
+  let retries=5
+  while ! nc -z -w 5 nginx 80; do
+    if [ "$retries" -le 0 ]; then
+      return 1
+    fi
+
+    retries=$(( $retries - 1 ))
+    sleep 1
+  done
+}
+
+@test "app container is up" {
+  run wait_for nginx 80
+}
+
+@test "wordpress is up" {
+  run curl --silent --fail http://nginx:80/
+  [ $status -eq 0 ]
+}


### PR DESCRIPTION
This improves our CI tests. We run a complete setup, similar to what we do in develop and then run a simple BATS integration test to check that the service is responding over HTTP.

With the integration framework in place, we can add more complex tests in the future, like checking that the theme CSS exists so we know the theme is loading correctly.