### PR TITLE
Additional steps to access admin dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,20 @@ environment.
 
     $ docker-compose exec -T db mysql -u root -pmysql-dev-password datagov \
       < <(gzip --to-stdout --decompress databasedump.sql.gz)
+
+## Admin dashboard
+
+In order to access the admin dashboard for development, you must first disable
+saml and update the admin password.
+
+First, deactivate the saml plugin.
+
+    $ docker-compose exec app wp --allow-root plugin deactivate saml-20-single-sign-on
+
+Reset the admin password to `password`.
+
+    $ docker-compose run --rm app wp --allow-root user update admin --user_pass=password
+
+Open the login page
+[localhost:8000/wp/wp-login.php](http://localhost:8000/wp/wp-login.php). Login
+with the user `admin` password `password`.


### PR DESCRIPTION
With some investigation, I was able to get into the admin dashboard for local development. I captured the additional steps necessary.

Right now we install all the plugins, but we probably want an explicit whitelist and exclude the samle plugin (and others). We can also include the admin password reset as part of the default setup. This would mean that no additional steps would be necessary to access the admin dashboard.