### PR TITLE
Remove si-captcha

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
     "wpackagist-plugin/plugin-vulnerabilities": "*",
     "wpackagist-plugin/posts-in-page": "*",
     "wpackagist-plugin/redirection": "*",
-    "wpackagist-plugin/si-captcha-for-wordpress": "*",
     "wpackagist-plugin/simple-tooltips": "*",
     "wpackagist-plugin/ssl-insecure-content-fixer": "*",
     "wpackagist-plugin/the-events-calendar": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -1778,16 +1778,6 @@
             "homepage": "https://wordpress.org/plugins/redirection/"
         },
         {
-            "name": "wpackagist-plugin/si-captcha-for-wordpress",
-            "version": "3.0.3",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/si-captcha-for-wordpress/",
-                "reference": "tags/3.0.3"
-            },
-            "type": "library"
-        },
-        {
             "name": "wpackagist-plugin/simple-tooltips",
             "version": "2.1.3",
             "source": {


### PR DESCRIPTION
si-captcha is a unsupported plugin, see details in the [official Wordpress blogs](https://wptavern.com/si-captcha-anti-spam-plugin-permanently-removed-from-wordpress-og-due-to-spam-code) and the [public repo](https://github.com/wp-plugins/si-captcha-for-wordpress).

The composer installation fails to install this plugin regularly, this will clean up deployments.

The feedback form does not use captcha, so it can be safely removed.